### PR TITLE
T179375 improve failover behaviour

### DIFF
--- a/Products/ZPsycopgDA/db.py
+++ b/Products/ZPsycopgDA/db.py
@@ -203,7 +203,14 @@ class DB(TM, dbi_db.DB):
             self._commit(put_connection=True)
 
     def _abort(self, *ignored):
-        conn = self.getconn(False)
+        # In cases where the _abort() occurs because the connection to the
+        # database failed, getconn() will fail also.
+        try:
+            conn = self.getconn(False)
+        except psycopg2.OperationalError:
+            LOG.error('getconn() failed during abort.')
+            return
+
         try:
             if self.use_tpc:
                 # TODO An error can occur if this connector

--- a/Products/ZPsycopgDA/db.py
+++ b/Products/ZPsycopgDA/db.py
@@ -207,7 +207,7 @@ class DB(TM, dbi_db.DB):
         # database failed, getconn() will fail also.
         try:
             conn = self.getconn(False)
-        except psycopg2.OperationalError:
+        except psycopg2.Error:
             LOG.error('getconn() failed during abort.')
             return
 
@@ -315,6 +315,10 @@ class DB(TM, dbi_db.DB):
         ) or (
             name == 'InterfaceError' and (
                 'connection already closed' in value
+            )
+        ) or (
+            name == 'NotSupportedError' and (
+                'cannot set transaction read-write mode' in value
             )
         )
         if connection_closed_error:


### PR DESCRIPTION
During fail-over tests, some recoverable errors still bubble up to the Zope application, which is not optimal.

These errors are caught with the changes proposed in this PR.