### PR TITLE
Make 'SSL connection has been closed unexpectedly' retryable

### DIFF
--- a/Products/ZPsycopgDA/db.py
+++ b/Products/ZPsycopgDA/db.py
@@ -314,7 +314,8 @@ class DB(TM, dbi_db.DB):
                 'could not connect to server' in value or
                 'the database system is shutting down' in value or
                 'the database system is starting up' in value or
-                'terminating connection due to administrator command' in value
+                'terminating connection due to administrator command' in value or
+                'SSL connection has been closed unexpectedly' in value
             )
         ) or (
             name == 'InterfaceError' and (


### PR DESCRIPTION
Add the OperationalError  'SSL connection has been closed unexpectedly' to the list of retryable errors