### PR TITLE
T197241: Directly reconnect database connection if this is the first …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.4.7.dev1+perfact.2
+--------------------
+
+Directly reconnect broken connections if this is the first query in the
+transaction instead of directly raising a RetryError.
+
+
 2.4.7.dev1+perfact.1
 -------------------
 Collection of PerFact patches to the Product, including reorganization of how

--- a/Products/ZPsycopgDA/__init__.py
+++ b/Products/ZPsycopgDA/__init__.py
@@ -16,7 +16,7 @@
 # their work without bothering about the module dependencies.
 
 __doc__ = "ZPsycopg Database Adapter Registration."
-__version__ = '2.4.7.dev1+perfact.1'
+__version__ = '2.4.7.dev1+perfact.2'
 
 # Python2 backward compatibility
 try:


### PR DESCRIPTION
In a situation where the database connections are idle for some time and are killed by `measure` because there were locks or something alike, we can reconnect directly instead of retrying the complete request (which might hit the `max_conflict_retries` limit rather fast in some situations)