### PR TITLE
ZMI: Improved GUI-compatibility to Zope4+

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.4.8
+--------------------
+
+Restuctered ZMI according to Zope4+ 
+
+
 2.4.7.dev1+perfact.4
 --------------------
 

--- a/Products/ZPsycopgDA/DA.py
+++ b/Products/ZPsycopgDA/DA.py
@@ -81,6 +81,8 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
     database_type = 'Psycopg2'
     meta_type = title = 'Z Psycopg 2 Database Connection'
     icon = 'misc_/conn'
+    zmi_icon = 'fas fa-database text-info'
+    zmi_show_add_dialog = True
 
     def __init__(self, id, title, connection_string,
                  zdatetime, check=None, tilevel=DEFAULT_TILEVEL,

--- a/Products/ZPsycopgDA/__init__.py
+++ b/Products/ZPsycopgDA/__init__.py
@@ -16,7 +16,7 @@
 # their work without bothering about the module dependencies.
 
 __doc__ = "ZPsycopg Database Adapter Registration."
-__version__ = '2.4.7.dev1+perfact.4'
+__version__ = '2.4.8'
 
 # Python2 backward compatibility
 try:

--- a/Products/ZPsycopgDA/dtml/add.dtml
+++ b/Products/ZPsycopgDA/dtml/add.dtml
@@ -6,159 +6,131 @@
            help_topic='ZPsycopgDA-Method-Add.stx'
            )">
 
-<p class="form-help">
-A Zope Psycopg 2 Database Connection is used to connect and execute
-queries on a PostgreSQL database.
-</p>
+<main class="container-fluid">
 
-<p class="form-help">
-In the form below <em>Connection String</em> (also called the Data Source Name
-or DSN for short) is a string containing the connection parameters, for
-example: “dbname=test user=postgres password=secret”
-</p>
+  <p class="form-help">
+    A Zope Psycopg 2 Database Connection is used to connect and execute
+    queries on a PostgreSQL database. In the form below <em>Connection String</em> 
+    (also called the Data Source Name or DSN for short) is a string containing 
+    the connection parameters, for example: 
+    <samp>“dbname=test user=postgres password=secret”</samp>
+  </p>
 
-<p class="form-help">
-The basic connection parameters are:
-<ul>
-    <li>dbname: the database name (only in dsn string)</li>
-    <li>database: the database name (only as keyword argument)</li>
-    <li>user: user name used to authenticate</li>
-    <li>password: password used to authenticate</li>
-    <li>host: database host address (defaults to UNIX socket if not provided)</li>
-    <li>port: connection port number (defaults to 5432 if not provided)</li>
-</ul>
-</p>
+  <form action="manage_addZPsycopgConnection" method="POST">
+    <div class="form-group row">
+      <label for="id" class="form-label col-sm-4 col-md-3">Id</label>
+      <div class="col-sm-8 col-md-9">
+        <input id="id" class="form-control" type="text" name="id" 
+          placeholder="Psycopg2_database_connection"
+          value="Psycopg2_database_connection" />
+      </div>
+    </div>
 
-<p class="form-help">
-<b>Note on transaction levels:</b> Unless your server is capable of retries
-(Setting "max-conflict-retries" in zope.conf), you should not use
-"repeatable read" or "serializable", because both can produce random errors
-on contradicting transactions.
-</p>
+    <div class="form-group row">
+      <label for="title" class="form-label col-sm-4 col-md-3">Title</label>
+      <div class="col-sm-8 col-md-9">
+        <input id="title" class="form-control" type="text" name="title" 
+          placeholder="Z Psycopg 2 Database Connection"
+          value="Z Psycopg 2 Database Connection" />
+      </div>
+    </div>
 
-<p class="form-help">
-<b>Note on two-phase commit:</b> This feature uses "PREPARE TRANSACTION", which
-has some limitations (no NOTIFY or LISTEN is possible), and needs special
-provisions to clean up orphaned prepared transactions. Use with care.
-</p>
+    <div class="form-group row">
+      <label for="connection_string" class="form-label col-sm-4 col-md-3">Connection string</label>
+      <div class="col-sm-8 col-md-9">
+        <input id="connection_string" class="form-control" type="text" name="connection_string" 
+          placeholder="dbname=test user=postgres password=secret" 
+          value="" />
+        <small>
+          The basic connection parameters are:
+          <br/>
+          <code>dbname</code>: the database name (only in dsn string)
+          <br />
+          <code>database</code>: the database name (only as keyword argument)
+          <br />
+          <code>user</code>: user name used to authenticate
+          <br />
+          <code>password</code>: password used to authenticate
+          <br />
+          <code>host</code>: database host address (defaults to UNIX socket if not provided)
+          <br />
+          <code>port</code>: connection port number (defaults to 5432 if not provided)
+        </small>
+      </div>
+    </div>
 
-<form action="manage_addZPsycopgConnection" method="POST">
-<table cellspacing="0" cellpadding="2" border="0">
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Id
+    <div class="form-group row">
+      <label for="check" class="form-label col-sm-4 col-md-3">Connect immediately</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="btn btn-primary" type="checkbox" id="check" name="check" value="YES" checked="YES" class="form-control"/>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="text" name="id" size="40"
-           value="Psycopg2_database_connection" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-optional">
-    Title
+
+    <div class="form-group row">
+      <label for="zdatetime" class="form-label col-sm-4 col-md-3">Use Zope's internal DateTime</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="btn btn-primary" type="checkbox" id="zdatetime" name="zdatetime" value="YES" checked="YES" class="form-control"/>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="text" name="title" size="40"
-        value="Z Psycopg 2 Database Connection"/>
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Connection string
+
+    <div class="form-group row">
+      <label for="tilevel" class="form-label col-sm-4 col-md-3">Transaction isolation level</label>
+      <div class="col-sm-8 col-md-9">
+        <select class="form-control" id="tilevel" name="tilevel:int">
+          <option value="4">Read uncommitted</option>
+          <option value="1">Read committed</option>
+          <option value="2" selected="YES">Repeatable read</option>
+          <option value="3">Serializable</option>
+        </select>
+        <small>
+          Note: Unless your server is capable of retries (Setting <samp>max-conflict-retries</samp> 
+          in zope.conf), you should not use <samp>repeatable read</samp> or <samp>serializable</samp>, 
+          because both can produce random errors on contradicting transactions.
+        </small>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="text" name="connection_string" size="40" value="" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Connect immediately
+
+    <div class="form-group row">
+      <label for="autocommit" class="form-label col-sm-4 col-md-3">Auto-commit each query</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="btn btn-primary" type="checkbox" id="autocommit" name="autocommit" value="YES" checked="YES" class="form-control"/>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="check" value="YES" checked="YES" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Use Zope's internal DateTime
+
+    <div class="form-group row">
+      <label for="readonlymode" class="form-label col-sm-4 col-md-3">Read-only mode</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="btn btn-primary" type="checkbox" id="readonlymode" name="readonlymode" value="YES" checked="YES" class="form-control"/>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="zdatetime" value="YES" checked="YES" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Transaction isolation level
+
+    <div class="form-group row">
+      <label for="use_tpc" class="form-label col-sm-4 col-md-3">Use Two-Phase Commit</label>
+      <div class="col-sm-8 col-md-9">
+        <input class="btn btn-primary" type="checkbox" id="use_tpc" name="use_tpc" value="YES" checked="YES" class="form-control"/>
+        <small class="d-block">
+          Note: "Two-Phase Commit" uses <samp>PREPARE TRANSACTION</samp>, which 
+          has some limitations (no <samp>NOTIFY</samp> or <samp>LISTEN</samp> is possible), 
+          and needs special provisions to clean up orphaned prepared transactions. 
+          Use with care.
+        </small>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-      <select name="tilevel:int">
-        <option value="4">Read uncommitted</option>
-        <option value="1">Read committed</option>
-        <option value="2" selected="YES">Repeatable read</option>
-        <option value="3">Serializable</option>
-      </select>
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Auto-commit each query
+
+    <div class="form-group row">
+      <label for="encoding" class="form-label col-sm-4 col-md-3">Encoding</label>
+      <div class="col-sm-8 col-md-9">
+        <input id="encoding" class="form-control" type="text" name="encoding"
+          placeholder="UTF-8" 
+          value="" />
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="autocommit" value="YES" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Read-only mode
+
+    <div class="zmi-controls">
+      <input class="btn btn-primary" type="submit" name="submit" value=" Add " />
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="readonlymode" value="YES" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Use Two-Phase Commit
-    </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="use_tpc" value="YES" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Encoding
-    </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="text" name="encoding" size="40" value="" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top" colspan="2">
-    <div class="form-element">
-    <input class="form-element" type="submit" name="submit" value=" Add " />
-    </div>
-    </td>
-  </tr>
-</table>
-</form>
+  </form>
+
+</main>
 
 <dtml-var manage_page_footer>

--- a/Products/ZPsycopgDA/dtml/edit.dtml
+++ b/Products/ZPsycopgDA/dtml/edit.dtml
@@ -1,148 +1,116 @@
 <dtml-var manage_page_header>
 <dtml-var manage_tabs>
 
-<p class="form-help">
-In the form below <em>Connection String</em> (also called the Data Source Name
-or DSN for short) is a string containing the connection parameters, for
-example: “dbname=test user=postgres password=secret”
-</p>
+<main class="container-fluid">
 
-<p class="form-help">
-The basic connection parameters are:
-<ul>
-    <li>dbname: the database name (only in dsn string)</li>
-    <li>database: the database name (only as keyword argument)</li>
-    <li>user: user name used to authenticate</li>
-    <li>password: password used to authenticate</li>
-    <li>host: database host address (defaults to UNIX socket if not provided)</li>
-    <li>port: connection port number (defaults to 5432 if not provided)</li>
-</ul>
-</p>
+  <p class="form-help">
+    A Zope Psycopg 2 Database Connection is used to connect and execute
+    queries on a PostgreSQL database. In the form below <em>Connection String</em> 
+    (also called the Data Source Name or DSN for short) is a string containing 
+    the connection parameters, for example: 
+    <samp>“dbname=test user=postgres password=secret”</samp>
+  </p>
 
-<p class="form-help">
-<b>Note on transaction levels:</b> Unless your server is capable of retries
-(Setting "max-conflict-retries" in zope.conf), you should not use
-"repeatable read" or "serializable", because both can produce random errors
-on contradicting transactions.
-</p>
+  <form action="manage_edit" method="POST">
+    <div class="form-group row">
+      <label for="title" class="form-label col-sm-4 col-md-3">Title</label>
+      <div class="col-sm-8 col-md-9">
+        <input id="title" class="form-control" type="text" name="title" 
+          placeholder="&dtml-title;"
+          value="&dtml-title;" />
+      </div>
+    </div>
 
-<p class="form-help">
-<b>Note on two-phase commit:</b> This feature uses "PREPARE TRANSACTION", which
-has some limitations (no NOTIFY or LISTEN is possible), and needs special
-provisions to clean up orphaned prepared transactions. Use with care.
-</p>
+    <div class="form-group row">
+      <label for="connection_string" class="form-label col-sm-4 col-md-3">Connection string</label>
+      <div class="col-sm-8 col-md-9">
+        <input id="connection_string" class="form-control" type="text" name="connection_string" 
+          placeholder="dbname=test user=postgres password=secret"
+          value="&dtml-connection_string;"/>
+        <small>
+          The basic connection parameters are:
+          <br/>
+          <code>dbname</code>: the database name (only in dsn string)
+          <br />
+          <code>database</code>: the database name (only as keyword argument)
+          <br />
+          <code>user</code>: user name used to authenticate
+          <br />
+          <code>password</code>: password used to authenticate
+          <br />
+          <code>host</code>: database host address (defaults to UNIX socket if not provided)
+          <br />
+          <code>port</code>: connection port number (defaults to 5432 if not provided)
+        </small>
+      </div>
+    </div>
 
-<form action="manage_edit" method="POST">
-<table cellspacing="0" cellpadding="2" border="0">
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-optional">
-    Title
+    <div class="form-group row">
+      <label for="zdatetime" class="form-label col-sm-4 col-md-3">Use Zope's internal DateTime</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="btn btn-primary" type="checkbox" id="zdatetime" name="zdatetime" value="YES" checked="YES" class="form-control" <dtml-if expr="zdatetime">checked="YES"</dtml-if>/>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="text" name="title" size="40"
-        value="&dtml-title;"/>
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Connection string
+
+    <div class="form-group row">
+      <label for="tilevel" class="form-label col-sm-4 col-md-3">Transaction isolation level</label>
+      <div class="col-sm-8 col-md-9">
+        <select id="tilevel" class="form-control" name="tilevel:int">
+          <option value="4" <dtml-if expr="tilevel==4">selected="YES"</dtml-if>>Read uncommitted</option>
+          <option value="1" <dtml-if expr="tilevel==1">selected="YES"</dtml-if>>Read committed</option>
+          <option value="2" <dtml-if expr="tilevel==2">selected="YES"</dtml-if>>Repeatable read</option>
+          <option value="3" <dtml-if expr="tilevel==3">selected="YES"</dtml-if>>Serializable</option>
+        </select>
+        <small>
+          Note: Unless your server is capable of retries (Setting <samp>max-conflict-retries</samp> 
+          in zope.conf), you should not use <samp>repeatable read</samp> or <samp>serializable</samp>, 
+          because both can produce random errors on contradicting transactions.
+        </small>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="text" name="connection_string" size="40"
-           value="&dtml-connection_string;" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Use Zope's internal DateTime
+
+
+    <div class="form-group row">
+      <label for="autocommit" class="form-label col-sm-4 col-md-3">Auto-commit each query</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="btn btn-primary" type="checkbox" id="autocommit" name="autocommit" value="YES" checked="YES" class="form-control"/>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="zdatetime" value="YES"
-      <dtml-if expr="zdatetime">checked="YES"</dtml-if> />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Transaction isolation level
+
+    <div class="form-group row">
+      <label for="readonlymode" class="form-label col-sm-4 col-md-3">Read-only mode</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="btn btn-primary" type="checkbox" id="readonlymode" name="readonlymode" value="YES" checked="YES" class="form-control"/>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-      <select name="tilevel:int">
-        <option value="4"
-                <dtml-if expr="tilevel==4">selected="YES"</dtml-if>>
-        Read uncommitted</option>
-        <option value="1"
-                <dtml-if expr="tilevel==1">selected="YES"</dtml-if>>
-        Read committed</option>
-        <option value="2"
-                <dtml-if expr="tilevel==2">selected="YES"</dtml-if>>
-        Repeatable read</option>
-        <option value="3"
-                <dtml-if expr="tilevel==3">selected="YES"</dtml-if>>
-        Serializable</option>
-      </select>
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Auto-commit each query
+
+    <div class="form-group row">
+      <label for="use_tpc" class="form-label col-sm-4 col-md-3">Use Two-Phase Commit</label>
+      <div class="col-sm-8 col-md-9">
+        <input class="btn btn-primary" type="checkbox" id="use_tpc" name="use_tpc" value="YES" checked="YES" class="form-control"/>
+        <small class="d-block">
+          Note: "Two-Phase Commit" uses <samp>PREPARE TRANSACTION</samp>, which 
+          has some limitations (no <samp>NOTIFY</samp> or <samp>LISTEN</samp> is possible), 
+          and needs special provisions to clean up orphaned prepared transactions. 
+          Use with care.
+        </small>
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="autocommit" value="YES"
-      <dtml-if autocommit>checked="YES"</dtml-if> />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Read-only mode
+
+    <div class="form-group row">
+      <label for="encoding" class="form-label col-sm-4 col-md-3">Encoding</label>
+      <div class="col-sm-8 col-md-9">
+        <input id="encoding" class="form-control" type="text" name="encoding" 
+          placeholder="UTF-8"
+          value="&dtml-encoding;" />
+      </div>
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="readonlymode" value="YES"
-      <dtml-if readonlymode>checked="YES"</dtml-if> />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Use Two-Phase Commit
+
+    <div class="zmi-controls">
+      <input class="btn btn-primary" type="submit" name="submit" value=" Save Changes " />
     </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="checkbox" name="use_tpc" value="YES"
-      <dtml-if use_tpc>checked="YES"</dtml-if> />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top">
-    <div class="form-label">
-    Encoding
-    </div>
-    </td>
-    <td align="left" valign="top">
-    <input type="text" name="encoding" size="40"
-           value="&dtml-encoding;" />
-    </td>
-  </tr>
-  <tr>
-    <td align="left" valign="top" colspan="2">
-    <div class="form-element">
-    <input class="form-element" type="submit" name="submit"
-     value=" Save Changes " />
-    </div>
-    </td>
-  </tr>
-</table>
-</form>
+  </form>
+
+</main>
 
 <dtml-var manage_page_footer>

--- a/psycopg2da/adapter.py
+++ b/psycopg2da/adapter.py
@@ -62,7 +62,7 @@ def parse_date(s):
     """
     m = _dateFmt.match(s)
     if m is None:
-        raise ValueError, 'invalid date string: %s' % s
+        raise ValueError('invalid date string: %s' % s)
     year, month, day = m.groups()
     return int(year), int(month), int(day)
 
@@ -83,7 +83,7 @@ def parse_time(s):
     """
     m = _timeFmt.match(s)
     if m is None:
-        raise ValueError, 'invalid time string: %s' % s
+        raise ValueError('invalid time string: %s' % s)
     hr, mn, sc, msc = m.groups(0)
     if msc != 0:
         sc = float("%s.%s" % (sc, msc))
@@ -108,7 +108,7 @@ def parse_tz(s):
         return 0
     m = _tzFmt.match(s)
     if m is None:
-        raise ValueError, 'invalid time zone: %s' % s
+        raise ValueError('invalid time zone: %s' % s)
     d, hoff, moff = m.groups(0)
     if d == "-":
         return - int(hoff) * 60 - int(moff)
@@ -145,7 +145,7 @@ def _split_datetime(s):
     """
     m = _datetimeFmt.search(s)
     if m is None:
-        raise ValueError, 'time part of datetime missing: %s' % s
+        raise ValueError('time part of datetime missing: %s' % s)
     pos = m.start()
     return s[:pos], s[pos + 1:]
 
@@ -224,7 +224,7 @@ def parse_interval(s):
         elif unit == 'years':
             years += int(count)
         else:
-            raise ValueError, 'unknown time interval %s %s' % (count, unit)
+            raise ValueError('unknown time interval %s %s' % (count, unit))
     if len(elements) % 2 == 1:
         hours, minutes, seconds = parse_time(elements[-1])
     return (years, months, days, hours, minutes, seconds)
@@ -332,8 +332,8 @@ class Psycopg2Adapter(ZopeDatabaseAdapter):
                 self._v_connection = Psycopg2Connection(
                         self._connection_factory(), self
                         )
-            except psycopg2.Error, error:
-                raise DatabaseException, str(error)
+            except psycopg2.Error as error:
+                raise DatabaseException(str(error))
 
     def registerTypes(self):
         registerTypes(self.getEncoding())
@@ -343,7 +343,7 @@ class Psycopg2Adapter(ZopeDatabaseAdapter):
         self.registerTypes()
         conn_info = parseDSN(self.dsn)
         conn_list = []
-        for dsnname, optname in dsn2option_mapping.iteritems():
+        for dsnname, optname in dsn2option_mapping.items():
             if conn_info[dsnname]:
                 conn_list.append('%s=%s' % (optname, conn_info[dsnname]))
         conn_str = ' '.join(conn_list)
@@ -386,7 +386,7 @@ class Psycopg2Connection(ZopeConnection):
     def commit(self):
         try:
             ZopeConnection.commit(self)
-        except psycopg2.Error, error:
+        except psycopg2.Error as error:
             _handle_psycopg_exception(error)
 
 
@@ -396,13 +396,13 @@ class Psycopg2Cursor(ZopeCursor):
         """See IZopeCursor"""
         try:
             return ZopeCursor.execute(self, operation, parameters)
-        except psycopg2.Error, error:
+        except psycopg2.Error as error:
             _handle_psycopg_exception(error)
 
     def executemany(operation, seq_of_parameters=None):
         """See IZopeCursor"""
-        raise RuntimeError, 'Oos'
+        raise RuntimeError('Oos')
         try:
             return ZopeCursor.execute(self, operation, seq_of_parameters)
-        except psycopg2.Error, error:
+        except psycopg2.Error as error:
             _handle_psycopg_exception(error)


### PR DESCRIPTION
Hi @jhinghaus,
remember our ZMI-sprint in Halle some time ago? These days I made some further ZMI cleaning with SQL related Products

1. https://github.com/zopefoundation/Products.ZSQLMethods
2. https://github.com/zopefoundation/Products.SQLAlchemyDA

The first one will affect your ZPsycopgDA-"Test"-GUI, too. Both changes are part of the master branches, now. Your ZPsycopgDA-fork seems to be the best maintained Postgres-connector, but there was another fork
https://github.com/huine/ZPsycopgDA/commits/master
which did quite a nice job in respect to Py3 compatibility and the new ZMI. But it looks as it refers to a former code status. So I tried to bring it together and added further ZMI-optimizations (e.g. syntax-hilight SQL editing).
In contrast to the author _huine_ I left some Zope2 specialties (like the old bitmap icons) in the code (for now) because I do not know, whether this may be still relevant for you. Maybe you can give me a feedback about that?

Of course it would be nice if the super-old code-status on pypi could updated, but the author seems to wait for test-codes of the extensions you contributed, for some time ;-)
https://github.com/psycopg/ZPsycopgDA/issues/4#issuecomment-643715201

Looking forward to your answer
f

SCREENS:
![ZSQLMethods](https://user-images.githubusercontent.com/29705216/102017306-7b541a80-3d66-11eb-8ee8-a32ff0460b62.gif)

![connection_add](https://user-images.githubusercontent.com/29705216/102017310-80b16500-3d66-11eb-981a-f5e58e5b45ad.gif)
