### PR TITLE
Revert version to 2.4.7.dev1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-2.4.8
+2.4.7.dev1+perfact.5
 --------------------
 
-Restuctered ZMI according to Zope4+ 
+Restuctered ZMI according to Zope4+
 
 
 2.4.7.dev1+perfact.4

--- a/Products/ZPsycopgDA/__init__.py
+++ b/Products/ZPsycopgDA/__init__.py
@@ -16,7 +16,7 @@
 # their work without bothering about the module dependencies.
 
 __doc__ = "ZPsycopg Database Adapter Registration."
-__version__ = '2.4.8'
+__version__ = '2.4.7.dev1+perfact.5'
 
 # Python2 backward compatibility
 try:


### PR DESCRIPTION
We decided to keep 2.4.7 version and only change the dev suffix.