### PR TITLE
Add option datetime_str

### DIFF
--- a/Products/ZPsycopgDA/DA.py
+++ b/Products/ZPsycopgDA/DA.py
@@ -193,11 +193,8 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
 
     def get_type_casts(self):
         # note that in both cases order *is* important
-        try:
-            if self.datetime_str:
-                return STRDATETIME, STRDATE, STRTIME
-        except AttributeError:  # datetime_str not present
-            pass
+        if getattr(self, 'datetime_str', False):
+            return STRDATETIME, STRDATE, STRTIME
         if self.zdatetime:
             return ZDATETIME, ZDATE, ZTIME
         else:

--- a/Products/ZPsycopgDA/DA.py
+++ b/Products/ZPsycopgDA/DA.py
@@ -64,10 +64,17 @@ def manage_addZPsycopgConnection(
         REQUEST=None):
     """Add a DB connection to a folder."""
     self._setObject(id, Connection(
-        id, title, connection_string,
-        zdatetime, check, tilevel, encoding,
-        autocommit, readonlymode, use_tpc,
-        datetime_str,
+        id=id,
+        title=title,
+        connection_string=connection_string,
+        zdatetime=zdatetime,
+        check=check,
+        tilevel=tilevel,
+        encoding=encoding,
+        autocommit=autocommit,
+        readonlymode=readonlymode,
+        use_tpc=use_tpc,
+        datetime_str=datetime_str,
     ))
     if REQUEST is not None:
         return self.manage_main(self, REQUEST)
@@ -95,10 +102,16 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
         self.zdatetime = zdatetime
         self.id = str(id)
         self.edit(
-            title, connection_string, zdatetime,
-            check=check, tilevel=tilevel, encoding=encoding,
-            autocommit=autocommit, readonlymode=readonlymode,
-            use_tpc=use_tpc, datetime_str=datetime_str,
+            title=title,
+            connection_string=connection_string,
+            zdatetime=zdatetime,
+            check=check,
+            tilevel=tilevel,
+            encoding=encoding,
+            autocommit=autocommit,
+            readonlymode=readonlymode,
+            use_tpc=use_tpc,
+            datetime_str=datetime_str,
         )
 
     def factory(self):
@@ -137,10 +150,16 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
             REQUEST=None):
         """Edit the DB connection."""
         self.edit(
-            title, connection_string, zdatetime,
-            check=check, tilevel=tilevel, encoding=encoding,
-            autocommit=autocommit, readonlymode=readonlymode,
-            use_tpc=use_tpc, datetime_str=datetime_str,
+            title=title,
+            connection_string=connection_string,
+            zdatetime=zdatetime,
+            check=check,
+            tilevel=tilevel,
+            encoding=encoding,
+            autocommit=autocommit,
+            readonlymode=readonlymode,
+            use_tpc=use_tpc,
+            datetime_str=datetime_str,
         )
         if REQUEST is not None:
             msg = "Connection edited."

--- a/Products/ZPsycopgDA/DA.py
+++ b/Products/ZPsycopgDA/DA.py
@@ -193,8 +193,11 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
 
     def get_type_casts(self):
         # note that in both cases order *is* important
-        if self.datetime_str:
-            return STRING, STRING, STRING
+        try:
+            if self.datetime_str:
+                return STRDATETIME, STRDATE, STRTIME
+        except AttributeError:  # datetime_str not present
+            pass
         if self.zdatetime:
             return ZDATETIME, ZDATE, ZTIME
         else:
@@ -321,11 +324,17 @@ def _cast_Time(iso, curs):
 def _cast_Interval(iso, curs):
     return iso
 
+def _cast_Str(iso, curs):
+    return iso
 
 ZDATETIME = new_type((1184, 1114), "ZDATETIME", _cast_DateTime)
 ZINTERVAL = new_type((1186,), "ZINTERVAL", _cast_Interval)
 ZDATE = new_type((1082,), "ZDATE", _cast_Date)
 ZTIME = new_type((1083,), "ZTIME", _cast_Time)
+
+STRDATETIME = new_type((1184, 1114), "STRDATETIME", _cast_Str)
+STRDATE = new_type((1082,), "STRDATE", _cast_Str)
+STRTIME = new_type((1083,), "STRTIME", _cast_Str)
 
 
 # table browsing helpers

--- a/Products/ZPsycopgDA/DA.py
+++ b/Products/ZPsycopgDA/DA.py
@@ -56,17 +56,19 @@ DEFAULT_TILEVEL = psycopg2.extensions.ISOLATION_LEVEL_REPEATABLE_READ
 manage_addZPsycopgConnectionForm = HTMLFile('dtml/add', globals())
 
 
-def manage_addZPsycopgConnection(self, id, title, connection_string,
-                                 zdatetime=None, tilevel=DEFAULT_TILEVEL,
-                                 encoding='', check=None,
-                                 autocommit=None,
-                                 readonlymode=None,
-                                 use_tpc=False,
-                                 REQUEST=None):
+def manage_addZPsycopgConnection(
+        self, id, title, connection_string,
+        zdatetime=None, tilevel=DEFAULT_TILEVEL, encoding='', check=None,
+        autocommit=None, readonlymode=None, use_tpc=False,
+        datetime_str=None,
+        REQUEST=None):
     """Add a DB connection to a folder."""
-    self._setObject(id, Connection(id, title, connection_string,
-                                   zdatetime, check, tilevel, encoding,
-                                   autocommit, readonlymode, use_tpc))
+    self._setObject(id, Connection(
+        id, title, connection_string,
+        zdatetime, check, tilevel, encoding,
+        autocommit, readonlymode, use_tpc,
+        datetime_str,
+    ))
     if REQUEST is not None:
         return self.manage_main(self, REQUEST)
 
@@ -84,26 +86,31 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
     zmi_icon = 'fas fa-database text-info'
     zmi_show_add_dialog = True
 
-    def __init__(self, id, title, connection_string,
-                 zdatetime, check=None, tilevel=DEFAULT_TILEVEL,
-                 encoding='UTF-8',
-                 autocommit=False, readonlymode=False,
-                 use_tpc=False):
+    def __init__(
+            self, id, title, connection_string,
+            zdatetime, check=None, tilevel=DEFAULT_TILEVEL,
+            encoding='UTF-8',
+            autocommit=False, readonlymode=False,
+            use_tpc=False, datetime_str=False):
         self.zdatetime = zdatetime
         self.id = str(id)
-        self.edit(title, connection_string, zdatetime,
-                  check=check, tilevel=tilevel, encoding=encoding,
-                  autocommit=autocommit, readonlymode=readonlymode,
-                  use_tpc=use_tpc)
+        self.edit(
+            title, connection_string, zdatetime,
+            check=check, tilevel=tilevel, encoding=encoding,
+            autocommit=autocommit, readonlymode=readonlymode,
+            use_tpc=use_tpc, datetime_str=datetime_str,
+        )
 
     def factory(self):
         return DB
 
     # connection parameters editing
 
-    def edit(self, title, connection_string,
-             zdatetime, check=None, tilevel=DEFAULT_TILEVEL, encoding='UTF-8',
-             autocommit=False, readonlymode=False, use_tpc=False):
+    def edit(
+            self, title, connection_string,
+            zdatetime, check=None, tilevel=DEFAULT_TILEVEL, encoding='UTF-8',
+            autocommit=False, readonlymode=False, use_tpc=False,
+            datetime_str=False):
         self.title = title
         self.connection_string = connection_string
         self.zdatetime = zdatetime
@@ -112,24 +119,29 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
         self.autocommit = autocommit
         self.readonlymode = readonlymode
         self.use_tpc = use_tpc
+        self.datetime_str = datetime_str
 
         if check:
             self.connect(self.connection_string)
 
     manage_properties = HTMLFile('dtml/edit', globals())
 
-    def manage_edit(self, title, connection_string,
-                    zdatetime=None, check=None, tilevel=DEFAULT_TILEVEL,
-                    encoding='UTF-8',
-                    autocommit=False,
-                    readonlymode=False,
-                    use_tpc=False,
-                    REQUEST=None):
+    def manage_edit(
+            self, title, connection_string,
+            zdatetime=None, check=None, tilevel=DEFAULT_TILEVEL,
+            encoding='UTF-8',
+            autocommit=False,
+            readonlymode=False,
+            use_tpc=False,
+            datetime_str=False,
+            REQUEST=None):
         """Edit the DB connection."""
-        self.edit(title, connection_string, zdatetime,
-                  check=check, tilevel=tilevel, encoding=encoding,
-                  autocommit=autocommit, readonlymode=readonlymode,
-                  use_tpc=use_tpc)
+        self.edit(
+            title, connection_string, zdatetime,
+            check=check, tilevel=tilevel, encoding=encoding,
+            autocommit=autocommit, readonlymode=readonlymode,
+            use_tpc=use_tpc, datetime_str=datetime_str,
+        )
         if REQUEST is not None:
             msg = "Connection edited."
             return self.manage_main(self, REQUEST, manage_tabs_message=msg)
@@ -181,6 +193,8 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
 
     def get_type_casts(self):
         # note that in both cases order *is* important
+        if self.datetime_str:
+            return STRING, STRING, STRING
         if self.zdatetime:
             return ZDATETIME, ZDATE, ZTIME
         else:

--- a/Products/ZPsycopgDA/dtml/add.dtml
+++ b/Products/ZPsycopgDA/dtml/add.dtml
@@ -59,7 +59,7 @@
     <div class="form-group row">
       <label for="check" class="form-label col-sm-4 col-md-3">Connect immediately</label>
       <div class="col-sm-5 col-md-1">
-        <input class="form-check-input" type="checkbox" id="check" name="check" value="YES" checked="checked" />
+        <input class="form-check-input" type="checkbox" id="check" name="check" value="YES" />
       </div>
     </div>
 
@@ -71,12 +71,19 @@
     </div>
 
     <div class="form-group row">
+      <label for="datetime_str" class="form-label col-sm-4 col-md-3">Pass date/time types as strings</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="form-check-input" type="checkbox" id="datetime_str" name="datetime_str" value="YES" />
+      </div>
+    </div>
+
+    <div class="form-group row">
       <label for="tilevel" class="form-label col-sm-4 col-md-3">Transaction isolation level</label>
       <div class="col-sm-8 col-md-9">
         <select class="form-control" id="tilevel" name="tilevel:int">
           <option value="4">Read uncommitted</option>
-          <option value="1">Read committed</option>
-          <option value="2" selected="selected">Repeatable read</option>
+          <option value="1" selected="selected">Read committed</option>
+          <option value="2">Repeatable read</option>
           <option value="3">Serializable</option>
         </select>
         <small>
@@ -90,21 +97,21 @@
     <div class="form-group row">
       <label for="autocommit" class="form-label col-sm-4 col-md-3">Auto-commit each query</label>
       <div class="col-sm-5 col-md-1">
-        <input class="form-check-input" type="checkbox" id="autocommit" name="autocommit" value="YES" checked="checked" />
+        <input class="form-check-input" type="checkbox" id="autocommit" name="autocommit" value="YES" />
       </div>
     </div>
 
     <div class="form-group row">
       <label for="readonlymode" class="form-label col-sm-4 col-md-3">Read-only mode</label>
       <div class="col-sm-5 col-md-1">
-        <input class="form-check-input" type="checkbox" id="readonlymode" name="readonlymode" value="YES" checked="checked" />
+        <input class="form-check-input" type="checkbox" id="readonlymode" name="readonlymode" value="YES" />
       </div>
     </div>
 
     <div class="form-group row">
       <label for="use_tpc" class="form-label col-sm-4 col-md-3">Use Two-Phase Commit</label>
       <div class="col-sm-8 col-md-9">
-        <input class="form-check-input" type="checkbox" id="use_tpc" name="use_tpc" value="YES" checked="checked" />
+        <input class="form-check-input" type="checkbox" id="use_tpc" name="use_tpc" value="YES" />
         <small class="d-block">
           Note: "Two-Phase Commit" uses <samp>PREPARE TRANSACTION</samp>, which
           has some limitations (no <samp>NOTIFY</samp> or <samp>LISTEN</samp> is possible),

--- a/Products/ZPsycopgDA/dtml/edit.dtml
+++ b/Products/ZPsycopgDA/dtml/edit.dtml
@@ -53,6 +53,13 @@
     </div>
 
     <div class="form-group row">
+      <label for="datetime_str" class="form-label col-sm-4 col-md-3">Pass date/time types as strings</label>
+      <div class="col-sm-5 col-md-1">
+        <input class="form-check-input" type="checkbox" id="datetime_str" name="datetime_str" value="YES" <dtml-if expr="datetime_str">checked="checked"</dtml-if>/>
+      </div>
+    </div>
+
+    <div class="form-group row">
       <label for="tilevel" class="form-label col-sm-4 col-md-3">Transaction isolation level</label>
       <div class="col-sm-8 col-md-9">
         <select id="tilevel" class="form-control" name="tilevel:int">

--- a/Products/ZPsycopgDA/dtml/edit.dtml
+++ b/Products/ZPsycopgDA/dtml/edit.dtml
@@ -55,7 +55,7 @@
     <div class="form-group row">
       <label for="datetime_str" class="form-label col-sm-4 col-md-3">Pass date/time types as strings</label>
       <div class="col-sm-5 col-md-1">
-        <input class="form-check-input" type="checkbox" id="datetime_str" name="datetime_str" value="YES" <dtml-if expr="datetime_str">checked="checked"</dtml-if>/>
+        <input class="form-check-input" type="checkbox" id="datetime_str" name="datetime_str" value="YES" <dtml-if datetime_str>checked="checked"</dtml-if>/>
       </div>
     </div>
 


### PR DESCRIPTION
This PR adds an option "datetime_str" to the connector, which disables all conversions of timestamps, dates, and times (with and without time zone), passing instead the ISO strings from the database.