### PR TITLE
T279834: Fill cause attr when raising RetryError and RetryDelayError

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,11 @@
 Changelog
 =========
+2.4.7.dev1+perfact.9
+--------------------
+
+When raising RetryError and RetryDelayError use from clause to also fill __cause__ attribute
+to get better stack trace on Errors with retries.
+
 
 2.4.7.dev1+perfact.8
 --------------------

--- a/Products/ZPsycopgDA/db.py
+++ b/Products/ZPsycopgDA/db.py
@@ -366,7 +366,7 @@ class DB(TM, dbi_db.DB):
     def handle_retry(self, error):
         '''Find out if an error deserves a retry.'''
         if self.is_serialization_error(error):
-            raise RetryError
+            raise RetryError from error
 
         connection_error = self.is_connection_error(error)
         server_error = self.is_server_error(error)
@@ -379,9 +379,9 @@ class DB(TM, dbi_db.DB):
             self.getconn().close()
 
         if connection_error:
-            raise RetryError
+            raise RetryError from error
         if server_error:
-            raise RetryDelayError
+            raise RetryDelayError from error
 
     # query execution
     def query(self, query_string, max_rows=None, query_data=None):


### PR DESCRIPTION
Add usage of from clause for RetryError and RetryDelayError in handle_retry method to fill __cause__ attribute to have fuller stack trace data on retry errors.
This development was tested on froneri-test system