### PR TITLE
Retry spurious errors from deadlocks

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,16 @@
 Changelog
 =========
+
+2.4.7.dev1+perfact.11
+---------------------
+
+Database Deadlock errors are now handled as RetryErrors, because they fall in
+the category of errors which cannot be completely eradicated in Read Committed
+transaction level, and therefore should be retried.
+
+
 2.4.7.dev1+perfact.10
---------------------
+---------------------
 
 When raising RetryError and RetryDelayError use from clause to also fill __cause__ attribute
 to get better stack trace on Errors with retries.

--- a/Products/ZPsycopgDA/db.py
+++ b/Products/ZPsycopgDA/db.py
@@ -381,7 +381,7 @@ class DB(TM, dbi_db.DB):
             raise RetryError from error
 
         if self.is_spurious_collision_error(error):
-            raise RetryError
+            raise RetryError from error
 
         connection_error = self.is_connection_error(error)
         server_error = self.is_server_error(error)


### PR DESCRIPTION
Transactions sometimes fail due to serialization problems which don't show up directly
as "serialization errors" in PostgreSQL. Those can be colliding updates from several 
almost simultaneous transactions, or deadlocks.

Such conditions can always happen and should be recovered by retrying.