### PR TITLE
T359999: Fix import performance eater

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2.4.7.dev1+perfact.12
+---------------------
+
+Importing "threading" is now done directly in the header of db.py. The
+try-except block removed by this change is a cause of major slow-down because
+the result is not cached by the interpreter and "import thread" is tried over
+and over again.
+
+
 2.4.7.dev1+perfact.11
 ---------------------
 

--- a/Products/ZPsycopgDA/db.py
+++ b/Products/ZPsycopgDA/db.py
@@ -24,6 +24,8 @@ from psycopg2.extensions import register_type
 from psycopg2 import NUMBER, STRING, ROWID, DATETIME
 from psycopg2.pool import AbstractConnectionPool, ThreadedConnectionPool
 
+import threading
+
 try:
     from Zope2.App.startup import RetryError, RetryDelayError
 except ImportError:
@@ -43,11 +45,6 @@ LOG = getLogger('ZPsycopgDA.db')
 
 def get_thread_id():
     '''Global function to retrieve the current thread id.'''
-    try:
-        import thread
-        threading = thread
-    except ImportError:
-        import threading
     return threading.get_ident()
 
 


### PR DESCRIPTION
This removes a performance problem produced by attempting to import a Python 2 module over and over again.